### PR TITLE
Workaround for log4j2 issues with Maven plugin.

### DIFF
--- a/log4j2.xml
+++ b/log4j2.xml
@@ -12,10 +12,6 @@
          </Policies>
          <DefaultRolloverStrategy max="10"/>
       </RollingFile>
-      <Async name="ASYNC">
-         <AppenderRef ref="ROLLING"/>
-         <AppenderRef ref="CONSOLE"/>
-      </Async>
    </Appenders>
    <Loggers>
       <Logger name="com" level="info"/>
@@ -23,7 +19,8 @@
       <Logger name="io.searchbox" level="warn"/>
       <Logger name="org.perfcake" level="info"/>
       <Root level="info">
-         <AppenderRef ref="ASYNC"/>
+         <AppenderRef ref="ROLLING"/>
+         <AppenderRef ref="CONSOLE"/>
       </Root>
    </Loggers>
 </Configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -41,12 +41,12 @@
 					<dependency>
 						<groupId>org.apache.logging.log4j</groupId>
 						<artifactId>log4j-api</artifactId>
-						<version>2.6.2</version>
+						<version>2.8</version>
 					</dependency>
 					<dependency>
 						<groupId>org.apache.logging.log4j</groupId>
 						<artifactId>log4j-core</artifactId>
-						<version>2.6.2</version>
+						<version>2.8</version>
 					</dependency>
 				</dependencies>
 			</plugin>


### PR DESCRIPTION
The workaround until 
https://issues.apache.org/jira/browse/LOG4J2-1642
https://issues.apache.org/jira/browse/LOG4J2-1830
are fixed.
